### PR TITLE
Implemented PassthroughLoggingHttpProxy.

### DIFF
--- a/src/main/java/com/github/kristofa/test/http/PassthroughForwardHttpRequestBuilder.java
+++ b/src/main/java/com/github/kristofa/test/http/PassthroughForwardHttpRequestBuilder.java
@@ -1,0 +1,39 @@
+package com.github.kristofa.test.http;
+
+import org.apache.commons.lang3.Validate;
+
+/**
+ * An implementation of {@link ForwardHttpRequestBuilder} that constructs {@link FullHttpRequest}s that redirects
+ * the request to the external service by changing the domain and port of the request.
+ * 
+ * @author dominiek
+ *
+ */
+public class PassthroughForwardHttpRequestBuilder implements ForwardHttpRequestBuilder {
+
+	private static final int MAXPORT = 65535;
+	private String targetDomain;
+	private int targetPort;
+
+	/**
+	 * Construct a new instance, incoming requests will be passed through to <code>targetDomain</code>:<code>targetPort</code> of the external service.
+	 * @param targetDomain the domain of the external service.
+	 * @param targetPort the port of the external service (between 1 and 65535).
+	 */
+	public PassthroughForwardHttpRequestBuilder(String targetDomain, int targetPort) {
+		Validate.notBlank(targetDomain);
+		Validate.inclusiveBetween(1, MAXPORT, targetPort);
+		this.targetDomain = targetDomain;
+		this.targetPort = targetPort;
+	}
+	
+	@Override
+	public FullHttpRequest getForwardRequest(FullHttpRequest request) {
+		// Use the copy-constructor and adjust domain and port.
+		FullHttpRequestImpl result= new FullHttpRequestImpl(request);
+		result.domain(targetDomain);
+		result.port(targetPort);
+		return result;
+	}
+
+}

--- a/src/main/java/com/github/kristofa/test/http/PassthroughLoggingHttpProxy.java
+++ b/src/main/java/com/github/kristofa/test/http/PassthroughLoggingHttpProxy.java
@@ -1,0 +1,23 @@
+package com.github.kristofa.test.http;
+
+import java.util.Collections;
+
+/**
+ * A {@link LoggingHttpProxy} that will behave as a pass-through proxy between the system-under-test and the external service.
+ * @author dominiek
+ *
+ */
+public class PassthroughLoggingHttpProxy extends LoggingHttpProxy {
+
+	/**
+	 * Construct a new instance.
+	 * @param port the local port.
+	 * @param targetDomain the target domain.
+	 * @param targetPort the target port.
+	 * @param loggerFactory the {@link HttpRequestResponseLoggerFactory}.
+	 */
+	public PassthroughLoggingHttpProxy(int port, String targetDomain, int targetPort, HttpRequestResponseLoggerFactory loggerFactory) {
+		super(port, Collections.<ForwardHttpRequestBuilder>singleton(new PassthroughForwardHttpRequestBuilder(targetDomain, targetPort)), loggerFactory);
+	}
+
+}

--- a/src/test/java/com/github/kristofa/test/http/PassthroughForwardHttpRequestBuilderTest.java
+++ b/src/test/java/com/github/kristofa/test/http/PassthroughForwardHttpRequestBuilderTest.java
@@ -1,0 +1,49 @@
+package com.github.kristofa.test.http;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PassthroughForwardHttpRequestBuilderTest {
+	private String targetDomain = "www.externalservice.com";
+	private int targetPort = 80;
+	private PassthroughForwardHttpRequestBuilder requestBuilder;
+	private byte[] data = "hello world".getBytes();
+
+	@Before
+	public void setUp() {
+		this.requestBuilder = new PassthroughForwardHttpRequestBuilder(targetDomain, targetPort);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testGetForwardRequest_NullDomain() {
+		new PassthroughForwardHttpRequestBuilder("", targetPort);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testGetForwardRequest_BadPort() {
+		new PassthroughForwardHttpRequestBuilder(targetDomain, Integer.MAX_VALUE);
+	}
+	
+	@Test
+	public void testGetForwardRequest() {
+		FullHttpRequestImpl inputRequest = new FullHttpRequestImpl();
+		inputRequest.domain("www.testservice.com");
+		inputRequest.port(8080);
+		inputRequest.path("/resource");
+		inputRequest.content(data);
+		inputRequest.method(Method.POST);
+		
+		FullHttpRequestImpl expectedRequest = new FullHttpRequestImpl();
+		expectedRequest.domain(targetDomain);
+		expectedRequest.port(targetPort);
+		expectedRequest.path("/resource");
+		expectedRequest.content(data);
+		expectedRequest.method(Method.POST);
+		
+		FullHttpRequest passthroughRequest = requestBuilder.getForwardRequest(inputRequest);
+		
+		assertEquals(expectedRequest, passthroughRequest);
+	}
+}

--- a/src/test/java/com/github/kristofa/test/http/PassthroughLoggingHttpProxyTest.java
+++ b/src/test/java/com/github/kristofa/test/http/PassthroughLoggingHttpProxyTest.java
@@ -1,0 +1,23 @@
+package com.github.kristofa.test.http;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class PassthroughLoggingHttpProxyTest {
+	private static final int port = 80;
+	private static final String targetDomain = "www.externalservice.com";
+	private static final int targetPort = 8080;
+	private HttpRequestResponseLoggerFactory loggerFactory;
+
+	@Before
+	public void setUp() {
+		loggerFactory = mock(HttpRequestResponseLoggerFactory.class);
+	}
+	
+	@Test
+	public void testConstruction() {
+		new PassthroughLoggingHttpProxy(port, targetDomain, targetPort, loggerFactory);
+	}
+}


### PR DESCRIPTION
Added PassthroughLoggingHttpProxy and PassthroughForwardHttpRequestBuilder to help out in setting up a domain and port passthrough to the external service.

Example usage:

> new PassthroughLoggingHttpProxy(PORT, "www.google.be", 80 , loggerFactory);

This will redirect all request on localhost:PORT to google.be:80 and log the conversation.
